### PR TITLE
Updating all the dependencies of BaseApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,15 @@ This BaseApp contains dependencies shared between ALL Sugar Labs applications.
 ```
 git clone --recurse-submodules https://github.com/flathub/org.sugarlabs.BaseApp.git
 cd org.sugarlabs.BaseApp
-flatpak -y --user install org.gnome.{Platform,Sdk}//44
+flatpak -y --user install flathub org.gnome.{Platform,Sdk}//46
 flatpak-builder --user --force-clean --install build org.sugarlabs.BaseApp.json
+```
+
+### Using beta builds (Optional)
+
+Execute this command to add flatpak beta repo
+```
+flatpak --user remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
 ```
 
 ## How To Update
@@ -21,9 +28,9 @@ flatpak --user install org.flathub.flatpak-external-data-checker
 
 Then edit `org.sugarlabs.BaseApp.json` to:
 
-1. Bump GNOME runtime to the latest stable version, e.g. `"runtime-version": "44"`
-2. Bump Python version references to the one included in the GNOME runtime, e.g. `flatpak --user run --command=python org.gnome.Platform//44 --version`
-3. Bump Perl version references to the one included in the GNOME SDK, e.g. `flatpak --user run --command=perl org.gnome.Sdk//44 --version`
+1. Bump GNOME runtime to the latest stable version, e.g. `"runtime-version": "46"`
+2. Bump Python version references to the one included in the GNOME runtime, e.g. `flatpak --user run --command=python org.gnome.Platform//46 --version`
+3. Bump Perl version references to the one included in the GNOME SDK, e.g. `flatpak --user run --command=perl org.gnome.Sdk//46 --version`
 4. Update `shared-modules` submodule with `git submodule update --remote`.
 5. Update every single module to the latest stable version. e.g. use `flatpak run --filesystem=$PWD org.flathub.flatpak-external-data-checker org.sugarlabs.BaseApp.json`
 

--- a/org.sugarlabs.BaseApp.json
+++ b/org.sugarlabs.BaseApp.json
@@ -1,12 +1,12 @@
 {
     "id": "org.sugarlabs.BaseApp",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "build-options": {
         "env": {
-            "PERL5LIB": "/app/lib/perl5/site_perl/5.36.0/"
+            "PERL5LIB": "/app/lib/perl5/site_perl/5.38.2/"
         }
     },
     "cleanup": [
@@ -37,7 +37,10 @@
                     "sha256": "73ac49785b601479df4ea18a7c79bc1304a8a7c34c02b9472cf1206ae88f01b3",
                     "x-checker-data": {
                         "type": "pypi",
-                        "name": "empy"
+                        "name": "empy",
+                        "versions": {
+                            "<": "4.0"
+                        }
                     }
                 }
             ],
@@ -45,9 +48,9 @@
                 "*"
             ],
             "post-install": [
-                "chmod +x /app/lib/python3.10/site-packages/em.py",
+                "chmod +x /app/lib/python3.11/site-packages/em.py",
                 "mkdir -p /app/bin/",
-                "ln -s /app/lib/python3.10/site-packages/em.py /app/bin/empy"
+                "ln -s /app/lib/python3.11/site-packages/em.py /app/bin/empy"
             ]
         },
         {
@@ -121,8 +124,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.sugarlabs.org/sources/sucrose/glucose/sugar-artwork/sugar-artwork-0.120.tar.xz",
-                    "sha256": "6052b4d3488daf78901d2914015e3c67017cb1bb0cf669625b1f1d62921e9afa",
+                    "url": "https://download.sugarlabs.org/sources/sucrose/glucose/sugar-artwork/sugar-artwork-0.121.tar.xz",
+                    "sha256": "d28a9b17ec54eab29f39e3dbd490956e9a588357209d523b1978c3df40d7bee2",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://download.sugarlabs.org/sources/sucrose/glucose/sugar-artwork/",
@@ -196,8 +199,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.sugarlabs.org/sources/sucrose/glucose/sugar-toolkit-gtk3/sugar-toolkit-gtk3-0.120.tar.xz",
-                    "sha256": "15476d1cc0bac2367ede4c855625cee88741c4d774908a7e633c264bb68b6928",
+                    "url": "https://download.sugarlabs.org/sources/sucrose/glucose/sugar-toolkit-gtk3/sugar-toolkit-gtk3-0.121.tar.xz",
+                    "sha256": "2b508b28d75fe30967de0650dcc67aaacfa579e707b043a2e43785c315039c57",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://download.sugarlabs.org/sources/sucrose/glucose/sugar-toolkit-gtk3/",
@@ -217,8 +220,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/tchx84/sugarapp.git",
-                    "tag": "v1.12",
-                    "commit": "2e2211b3bb7f8ba07a70d8d24131412e04c084ea",
+                    "tag": "v1.13",
+                    "commit": "e05147e156e2cb13ac99985e8670463ffcfc09de",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"


### PR DESCRIPTION
runtime-version updated to 45
Perl updated
python v3.11 is now available
Also added a note in the [README.md](https://github.com/SudoSu-bham/org.sugarlabs.BaseApp/blob/branch/24.04/README.md) which ask the user to not use `--user`  flags if the flatpak  applications are installed system-wide.